### PR TITLE
Fix for #2 Building of dependencies through gulp

### DIFF
--- a/irods-cloud-frontend/app/index.html
+++ b/irods-cloud-frontend/app/index.html
@@ -57,7 +57,7 @@
   <script src="../bower_components/angular-message-center/message-center.js"></script>
   <script src="../bower_components/ng-context-menu/dist/ng-context-menu.js"></script>
   <script src="../bower_components/angular-message-center/message-center-templates.js"></script>
-  <script src="../bower_components/ui-codemirror/ui-codemirror.js"></script>
+  <script src="../bower_components/angular-ui-codemirror/ui-codemirror.js"></script>
   <script src="app.js"></script>
   <script src="home/home.js"></script>
   <script src="dashboard/dashboard.js"></script>

--- a/irods-cloud-frontend/bower.json
+++ b/irods-cloud-frontend/bower.json
@@ -20,7 +20,7 @@
     "jquery-ui": "~1.11",
     "bootstrap": "~3.3.5",
     "jquery-mobile": "",
-    "ng-context-menu":""
+    "angular-ui-codemirror":""
   },
   "resolutions": {
     "jquery": "~1.11.3",

--- a/irods-cloud-frontend/bower.json
+++ b/irods-cloud-frontend/bower.json
@@ -20,7 +20,8 @@
     "jquery-ui": "~1.11",
     "bootstrap": "~3.3.5",
     "jquery-mobile": "",
-    "angular-ui-codemirror":""
+    "angular-ui-codemirror":"",
+    "components-font-awesome": "4.6.*"
   },
   "resolutions": {
     "jquery": "~1.11.3",

--- a/irods-cloud-frontend/gulpfile.js
+++ b/irods-cloud-frontend/gulpfile.js
@@ -15,7 +15,7 @@ gulp.task('default', function () {
 /**
  * Create a dist subdirectory that has the assembled javascript, css, images, html assets
  */
-gulp.task('dist', ['clean', 'vendor-scripts', 'app-scripts', 'css', 'images', 'html-assets','index-html-for-dist']);
+gulp.task('dist', ['clean', 'vendor-scripts', 'app-scripts', 'css', 'images', 'fonts', 'html-assets','index-html-for-dist']);
 
 /**
  * Package the web artifacts for deployment within the cloud browser backend war file
@@ -88,6 +88,7 @@ gulp.task('css',  ['clean'], function () {
         './bower_components/html5-boilerplate/css/*.css',
         './bower_components/angular-message-center/message-center.css',
         './bower_components/bootstrap/dist/css/bootstrap.min.css',
+        './bower_components/components-font-awesome/css/font-awesome.css',
         './app/sb-admin.css',
         './app/css/main.css'
     ])
@@ -117,6 +118,20 @@ gulp.task('html-assets',  ['clean'], function () {
     ],{ base: './app' })
         .pipe(gulp.dest('./dist'));
 
+});
+
+/**
+ * assemble all fonts into the fonts dir in the dist
+ */
+gulp.task('fonts',  ['clean'], function () {
+    // the base option sets the relative root for the set of files,
+    // preserving the folder structure
+    var filesToMove = [
+        './bower_components/components-font-awesome/fonts/*.*'
+    ];
+
+    return gulp.src(filesToMove, {base: './'}).pipe(flatten())
+        .pipe(gulp.dest('./dist/fonts'));
 });
 
 /**

--- a/irods-cloud-frontend/gulpfile.js
+++ b/irods-cloud-frontend/gulpfile.js
@@ -28,27 +28,34 @@ gulp.task('distToWar', ['dist'], function () {
         .pipe(gulp.dest('../irods-cloud-backend/web-app'));
 });
 
-gulp.task('clean', function(cb) {
-    del(['./dist'], cb);
+gulp.task('clean', function() {
+    del(['./dist']);
 });
 
 /**
  * assemble all vendor javascripts into a 'vendor.js'
  */
-gulp.task('vendor-scripts',  ['clean'], function () {
+gulp.task('vendor-scripts', ['clean'], function () {
     return gulp.src([
-        './bower_components/jquery/dist/jquery.min.js',
-        './bower_components/masonry/dist/masonry.pkgd.js',
-        './bower_components/jquery-ui/jquery-ui.min.js',
-        './bower_components/bootstrap/dist/js/bootstrap.min.js',
-        './bower_components/angular/angular.min.js',
-        './bower_components/angular-route/angular-route.js',
-        './bower_components/angular-animate/angular-animate.min.js',
-        './bower_components/angular-message-center/dist/message-center.min.js',
-        './bower_components/angular-message-center/message-center-templates.jss',
-        './bower_components/jquery-mobile/jquery.mobile.js',
-        './bower_components/ng-file-upload/ng-file-upload-shim.min.js',
-        './bower_components/ng-file-upload/ng-file-upload.min.js'])
+            './bower_components/angular/angular.min.js',
+            './bower_components/angular-resource/angular-resource.min.js',
+            './bower_components/angular-route/angular-route.js',
+            './bower_components/angular-animate/angular-animate.min.js',
+            './bower_components/jquery/dist/jquery.min.js',
+            './bower_components/masonry/dist/masonry.pkgd.min.js',
+            './bower_components/jquery-ui/jquery-ui.min.js',
+            './bower_components/bootstrap/dist/js/bootstrap.min.js',
+            './bower_components/jquery-mobile/jquery.mobile.js',
+            './bower_components/ng-file-upload/ng-file-upload-shim.min.js',
+            './bower_components/ng-file-upload/ng-file-upload.min.js',
+            './bower_components/ng-context-menu/dist/ng-context-menu.js',
+            './bower_components/angular-ui-codemirror/ui-codemirror.js',
+            './bower_components/angular-message-center/dist/message-center.min.js',
+            './bower_components/angular-message-center/message-center-templates.js',
+
+            // Node
+            './node_modules/node-uuid/uuid.js'
+        ])
         .pipe(concat('vendor.js'))
         .pipe(gulp.dest('./dist/js'));
 });
@@ -57,9 +64,17 @@ gulp.task('vendor-scripts',  ['clean'], function () {
  * assemble all application code javascripts into an 'app.js'
  */
 gulp.task('app-scripts', ['clean'], function () {
-    return gulp.src(['./app/app.js','./app/components/*.js',
-        './app/home/*.js', './app/login/*.js', './app/metadata/*.js',
-        './app/profile/*.js'])
+    return gulp.src([
+            './app/app.js',
+            './app/components/*.js',
+            './app/home/*.js',
+            './app/dashboard/*.js',
+            './app/edit/*.js',
+            './app/login/*.js',
+            './app/metadata/*.js',
+            './app/profile/*.js',
+            './app/search/*.js'
+        ])
         .pipe(concat('app.js'))
         .pipe(gulp.dest('./dist/js'));
 });
@@ -86,11 +101,18 @@ gulp.task('css',  ['clean'], function () {
  */
 
 gulp.task('html-assets',  ['clean'], function () {
-    return gulp.src(['./app/gallery/*.html',
+    return gulp.src([
+        './app/actions_pop_up.html',
+        './app/header.html',
+        './app/side_nav.html',
+        './app/gallery/*.html',
         './app/home/*.html',
+        './app/dashboard/*.html',
+        './app/edit/*.html',
         './app/login/*.html',
         './app/metadata/*.html',
         './app/profile/*.html',
+        './app/search/*.html'
 
     ],{ base: './app' })
         .pipe(gulp.dest('./dist'));

--- a/irods-cloud-frontend/package.json
+++ b/irods-cloud-frontend/package.json
@@ -17,7 +17,8 @@
     "karma": "~0.10",
     "karma-junit-reporter": "^0.2.2",
     "protractor": "^1.1.1",
-    "shelljs": "^0.2.6"
+    "shelljs": "^0.2.6",
+    "node-uuid": ""
   },
   "scripts": {
     "postinstall": "bower install",


### PR DESCRIPTION
This PR fixes the dependencies downloaded by npm and bower. It also fixes the building of the `./dist/` version of the cloudbrowser frontend by `gulp`. 

The next step would be to remove the dependencies included in the repository directly. Both those in the `app` directory, and the `bower_components` and `node_modules` directories.