### PR TITLE
fixes overflow of text

### DIFF
--- a/irods-cloud-frontend/app/css/main.css
+++ b/irods-cloud-frontend/app/css/main.css
@@ -1174,18 +1174,19 @@ input.col-xs-12{
 	-ms-user-select: none; 
 	user-select: none;
 }
-.light_back_option_even{
-	color:#000;
-	background: rgba(0,0,0,0.1);
-	opacity:0.7;
-	height:20px;
-	font-size: 12px;
-	width: 100%;
+.light_back_option_even {
+    color: #000;
+    background: rgba(0,0,0,0.1);
+    opacity: 0.7;
+    height: auto;
+    font-size: 12px;
+    width: 100%;
 }
-.light_back_option span, .light_back_option_even span{
-	padding: 0px 0px 4px 4px;
-	cursor: pointer;
+.light_back_option span, .light_back_option_even span {
+    padding: 0px 0px 4px 4px;
+    cursor: pointer;
     display: inline-block;
+    vertical-align: top;
 }
 .recent_query span{
 	width: 100%;


### PR DESCRIPTION
If metadata value, attribute, or unit breaks onto additional lines of text the column will grow to fit text height.

In essence, adds 2 lines:
height: auto;
vertical-align: top;